### PR TITLE
Fix: Remove sensitive stacktrace exposure from error response

### DIFF
--- a/src/main/java/com/example/userapi/controller/OrderController.java
+++ b/src/main/java/com/example/userapi/controller/OrderController.java
@@ -47,13 +47,9 @@ public class OrderController {
     }
 
     @GetMapping("/oops")
-    public String testEndpoint() {
-        try {
-            // Simulate an exception
-            throw new RuntimeException("Something went wrong!");
-        } catch (Exception e) {
-            // BAD PRACTICE: Leaking stack trace to the client
-            return e.toString() + "\n" + Arrays.toString(e.getStackTrace());
-        }
+    public ResponseEntity<string> testEndpoint() {
+        // Simulate an exception
+        // Let the global exception handler properly manage the error response
+        throw new RuntimeException("Something went wrong!");
     }
 }


### PR DESCRIPTION
This PR addresses the NoName API security finding (ID: 1284) that identified sensitive data being leaked in error messages.

### Changes made:

1. Modified the `/oops` test endpoint in `OrderController.java` to no longer expose stack traces directly to clients.
2. Changed the method to use Spring's standard exception handling mechanisms (GlobalExceptionHandler) to generate consistent, secure error responses.

### Security impact:

Stacktraces contain sensitive internal implementation details that should never be exposed to clients. This fix ensures that error responses are standardized and only include appropriate information without revealing system internals.